### PR TITLE
Works with ReSharper's test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ packages/
 [Bb]in
 [Dd]ebug*/
 [Rr]elease*/
+_ReSharper.*/

--- a/src/NSpecAdapterForXunit.Sample/Sample1.cs
+++ b/src/NSpecAdapterForXunit.Sample/Sample1.cs
@@ -52,4 +52,36 @@ namespace NSpecAdapterForXunit.Sample
             };
         }
     }
+
+    public class Sample2 : nspec
+    {
+        [Specification]
+        public void given_a_valid_date()
+        {
+            DateTime date = DateTime.Now;
+
+            before = () =>
+            {
+                date = DateTime.Now;
+            };
+
+            it["month should be greater than or equal to 1"] = () =>
+            {
+                date.Month.should_be_greater_or_equal_to(1);
+            };
+
+            it["month should be less than or equal to 12"] = () =>
+            {
+                date.Month.should_be_less_or_equal_to(12);
+            };
+
+            context["in a crazy world"] = () =>
+            {
+                it["day should be less than zero"] = () =>
+                {
+                    date.Day.should_be_less_than(0);
+                };
+            };
+        }
+    }
 }

--- a/src/NSpecAdapterForXunit/ExampleCommand.cs
+++ b/src/NSpecAdapterForXunit/ExampleCommand.cs
@@ -29,7 +29,7 @@ namespace NSpecAdapterForXunit
     /// <summary>
     /// Implements a <see cref="T:Xunit.Sdk.ITestCommand"/> that invokes all NSpec <see cref="T:NSpec.Domain.Example"/> in one method.
     /// </summary>
-    internal class ExampleCommand : ITestCommand
+    internal class ExampleCommand : TestCommand
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="T:NSpecAdapterForxUnit.ExampleCommand"/> to a specific <see cref="T:NSpec.Domain.Example"/>.
@@ -39,6 +39,7 @@ namespace NSpecAdapterForXunit
         /// <param name="instance">The instance to run the example.</param>
         /// <exception cref="T:System.ArgumentNullException">One of the arguments is <see langword="null"/>. </exception>
         public ExampleCommand(IMethodInfo method, Example example, nspec instance)
+            : base(method, example.FullName(), 0)
         {
             if (method == null)
             {
@@ -91,53 +92,15 @@ namespace NSpecAdapterForXunit
         }
 
         /// <summary>
-        /// Gets the display name of the test method.
-        /// </summary>
-        public string DisplayName
-        {
-            get
-            {
-                return Example.FullName();
-            }
-        }
-
-        /// <summary>
         /// Determines if the test runner infrastructure should create a new instance of the
         /// test class before running the test.
         /// </summary>
-        public bool ShouldCreateInstance
+        public override bool ShouldCreateInstance
         {
             get
             {
                 return false;
             }
-        }
-
-        /// <summary>
-        /// Determines if the test should be limited to running a specific amount of time
-        /// before automatically failing.
-        /// </summary>
-        /// <returns>The timeout value, in milliseconds; if zero, the test will not have
-        /// a timeout.</returns>
-        public int Timeout
-        {
-            get
-            {
-                return 0;
-            }
-        }
-
-        /// <summary>
-        /// Creates the start XML to be sent to the callback when the test is about to start
-        /// running.
-        /// </summary>
-        /// <returns>
-        /// Return the <see cref="T:System.Xml.XmlNode"/> of the start node, or null if the test
-        /// is known that it will not be running.
-        /// </returns>
-        public XmlNode ToStartXml()
-        {
-            return new XmlDocument().CreateElement("NSpec");
         }
 
         /// <summary>
@@ -147,7 +110,7 @@ namespace NSpecAdapterForXunit
         /// <returns>
         /// Returns information about the test run
         /// </returns>
-        public MethodResult Execute(object testClass)
+        public override MethodResult Execute(object testClass)
         {
             //run the example
             try
@@ -169,14 +132,7 @@ namespace NSpecAdapterForXunit
                         ex = ex.InnerException;
                     }
 
-                    return new FailedResult(
-                        this.Method.Name, //methodDate
-                        this.Method.TypeName, //typeName
-                        this.DisplayName, //displayName
-                        null, //traits
-                        ex.GetType().Name, //exceptionType
-                        ex.Message, //message
-                        ex.StackTrace); //stackTrace
+                    return new FailedResult(Method, ex, DisplayName);
                 }
                 else //TODO: this should be pending examples
                 {
@@ -196,14 +152,7 @@ namespace NSpecAdapterForXunit
                     ex = ex.InnerException;
                 }
 
-                return new FailedResult(
-                    this.Method.Name, //methodDate
-                    this.Method.TypeName, //typeName
-                    this.DisplayName, //displayName
-                    null, //traits
-                    ex.GetType().Name, //exceptionType
-                    ex.Message, //message
-                    ex.StackTrace); //stackTrace
+                return new FailedResult(Method, ex, DisplayName);
             }
         }
 


### PR DESCRIPTION
Small fixes to generate the right "start" xml for progress reporting and to report exceptions in the right format, and it now works with the xunitcontrib plugin for the ReSharper test runner. (RunWith isn't supported by the xunitcontrib plugin, but the Specification attribute works fine)
